### PR TITLE
prepare: add --offline option for offline compilation

### DIFF
--- a/commands/prepare.py
+++ b/commands/prepare.py
@@ -35,6 +35,8 @@ parser.add_option('', 'force_patch', 'boolean', 'force_patch',
 parser.add_option('c', 'complete', 'boolean', 'complete',
     _("Optional: completion mode, only prepare products not present in SOURCES dir."),
     False)
+parser.add_option('', 'offline', 'boolean', 'offline',
+    _("Optional: use only local archives; disable network; error if missing."))
 
 def find_products_already_prepared(l_products):
     '''function that returns the list of products that have an existing source 
@@ -166,7 +168,9 @@ Use the --force_patch option to overwrite it.
       
     # Construct the final commands arguments
     args_clean = args_appli + args_product_opt_clean + " --sources"
-    args_source = args_appli + args_product_opt  
+    args_source = args_appli + args_product_opt
+    if getattr(options, "offline", False):
+        args_source += " --offline"
     args_patch = args_appli + args_product_opt_patch
     # Initialize the results to a running status
     res_clean = 0
@@ -213,5 +217,4 @@ def removeInList(aList, removeList):
     res1 = [i for i in aList if i not in removeList]
     res2 = [i for i in aList if i in removeList]
     return (res1, res2)
-
 

--- a/commands/source.py
+++ b/commands/source.py
@@ -29,6 +29,10 @@ import src.debug as DBG
 parser = src.options.Options()
 parser.add_option('p', 'products', 'list2', 'products',
     _('Optional: products from which to get the sources. This option accepts a comma separated list.'))
+parser.add_option('', 'offline', 'boolean', 'offline',
+    _('Optional: use only local archives; disable network; error if missing.'))
+
+OFFLINE = False
 
 def get_source_for_dev(config, product_info, source_dir, logger, pad):
     '''The method called if the product is in development mode
@@ -191,19 +195,22 @@ def get_source_from_archive(config, product_info, source_dir, logger):
         logger.write(pip_msg, 3) 
         return True
 
+    # resolve archive path in local ARCHIVEPATH list
+    aname = product_info.archive_info.archive_name
+    if not os.path.isabs(aname) and not os.path.exists(aname):
+        found = src.find_file_in_lpath(aname, config.PATHS.ARCHIVEPATH)
+        if found:
+            product_info.archive_info.archive_name = found
     # check archive exists
     if not os.path.exists(product_info.archive_info.archive_name):
-        # The archive is not found on local file system (ARCHIVEPATH)
-        # We try ftp!
+        if OFFLINE:
+            raise src.SatException(_("Archive not found locally in ARCHIVEPATH: '%s'") % aname)
         logger.write("\n   The archive is not found on local file system, we try ftp\n", 3)
-        ret=src.find_file_in_ftppath(product_info.archive_info.archive_name, 
-                                     config.PATHS.ARCHIVEFTP, config.LOCAL.archive_dir, logger)
+        ret=src.find_file_in_ftppath(aname, config.PATHS.ARCHIVEFTP, config.LOCAL.archive_dir, logger)
         if ret:
-            # archive was found on ftp and stored in ret
             product_info.archive_info.archive_name=ret
         else:
-            raise src.SatException(_("Archive not found in ARCHIVEPATH, nor on ARCHIVEFTP: '%s'") % 
-                                   product_info.archive_info.archive_name)
+            raise src.SatException(_("Archive not found in ARCHIVEPATH, nor on ARCHIVEFTP: '%s'") % aname)
 
     logger.write('arc:%s ... ' % 
                  src.printcolors.printcInfo(product_info.archive_info.archive_name),
@@ -400,6 +407,48 @@ def get_product_sources(config,
                                    logger, 
                                    pad)
 
+    if OFFLINE and product_info.get_source in ["git","cvs","svn"]:
+        # try fallback to local archive by name
+        candidates = []
+        if "archive_info" in product_info and "archive_name" in product_info.archive_info:
+            candidates.append(product_info.archive_info.archive_name)
+        pname = product_info.name
+        candidates.append(pname + ".tar.gz")
+        candidates.append(pname.lower() + ".tar.gz")
+        candidates.append(pname.upper() + ".tar.gz")
+        found = None
+        for cname in candidates:
+            fp = src.find_file_in_lpath(cname, config.PATHS.ARCHIVEPATH)
+            if fp:
+                found = fp
+                break
+        if not found:
+            # try scanning archive directories for case-insensitive prefix match
+            for ap in config.PATHS.ARCHIVEPATH:
+                try:
+                    if not os.path.isdir(ap):
+                        continue
+                    for f in os.listdir(ap):
+                        fl = f.lower()
+                        if fl.endswith(".tar.gz") and (fl.startswith(pname.lower())):
+                            found = os.path.join(ap, f)
+                            break
+                    if found:
+                        break
+                except Exception:
+                    continue
+        if found:
+            # inject archive_info and switch to archive
+            try:
+                product_info.archive_info.archive_name = found
+            except Exception:
+                ai = src.pyconf.Mapping(product_info)
+                ai["archive_name"] = found
+                product_info.archive_info = ai
+            product_info.get_source = "archive"
+            return get_source_from_archive(config, product_info, source_dir, logger)
+        raise src.SatException(_("Offline mode: network source disabled for '%s', no local archive found") % product_info.name)
+
     if product_info.get_source == "git":
         return get_source_from_git(config, product_info, source_dir, logger, pad, 
                                     is_dev, env_appli)
@@ -583,6 +632,8 @@ def run(args, runner, logger):
     DBG.write("source.run()", args)
     # Parse the options
     (options, args) = parser.parse_args(args)
+    global OFFLINE
+    OFFLINE = bool(getattr(options, "offline", False))
     
     # check that the command has been called with an application
     src.check_config_has_application( runner.cfg )


### PR DESCRIPTION
Add a new --offline flag to sat prepare command.
This mode uses pre-downloaded archives in ARCHIVES directory instead of fetching sources from GitHub remotely.